### PR TITLE
Removed the duplicated biography info from the user profile page

### DIFF
--- a/resources/js/components/UserProfile.vue
+++ b/resources/js/components/UserProfile.vue
@@ -52,10 +52,6 @@
                             </p>
                         </div>
                     </div>
-
-                    <div class="card">
-                        <div class="card-body" v-html="user.biography"></div>
-                    </div>
                 </div>
 
                 <div class="row">


### PR DESCRIPTION
There is a duplicated biography info at the user profile page: https://laramap.com/@mankms 

Removed the first biography card.